### PR TITLE
sa67: enable loading U-Boot via DFU

### DIFF
--- a/board/kontron/sa67/common.c
+++ b/board/kontron/sa67/common.c
@@ -17,6 +17,7 @@ const char *spl_board_loader_name(u32 boot_device)
 	struct mmc *mmc;
 
 	switch (boot_device) {
+#if CONFIG_IS_ENABLED(DM_MMC)
 	case BOOT_DEVICE_MMC1:
 		mmc_init_device(0);
 		mmc = find_mmc_device(0);
@@ -24,6 +25,7 @@ const char *spl_board_loader_name(u32 boot_device)
 		snprintf(name, sizeof(name), "eMMC (%s)",
 			 emmc_hwpart_names[EXT_CSD_EXTRACT_BOOT_PART(mmc->part_config)]);
 		return name;
+#endif
 	case BOOT_DEVICE_MMC2:
 		return "SD card (Test mode)";
 	case BOOT_DEVICE_SPI:

--- a/board/kontron/sa67/sa67.env
+++ b/board/kontron/sa67/sa67.env
@@ -13,3 +13,9 @@ fdtfile=CONFIG_DEFAULT_FDT_FILE
 dfu_alt_info_ram=
 	tispl.bin ram 0x80080000 0x200000;
 	u-boot.img ram 0x81000000 0x400000
+dfu_alt_info=
+	sf 0:0=
+		boot.img raw 0x0 0x400000;
+		tiboot3.bin raw 0x0 0x080000;
+		tispl.bin raw 0x080000 0x180000;
+		u-boot.img raw 0x200000 0x200000

--- a/board/kontron/sa67/sa67.env
+++ b/board/kontron/sa67/sa67.env
@@ -9,3 +9,7 @@ bootm_size=0x10000000
 boot_fdt=try
 boot_targets=mmc0 mmc1 usb0 dhcp pxe
 fdtfile=CONFIG_DEFAULT_FDT_FILE
+
+dfu_alt_info_ram=
+	tispl.bin ram 0x80080000 0x200000;
+	u-boot.img ram 0x81000000 0x400000


### PR DESCRIPTION
For compiling, the `am62x_r5_usbdfu.config` fragment is needed in addition to `kontron_sa67_r5_defconfig.`
Includes a revert of 0b154e3bf92aa7cf5b3e57f1b7b2e45a2bf56bd4.