### PR TITLE
sa67: spl: split spl_board_fixups to arch/board specific

### DIFF
--- a/board/kontron/sa67/sa67.c
+++ b/board/kontron/sa67/sa67.c
@@ -252,7 +252,7 @@ int board_late_init(void)
 }
 
 #if IS_ENABLED(CONFIG_XPL_BUILD)
-void spl_perform_fixups(struct spl_image_info *spl_image)
+void spl_perform_board_fixups(struct spl_image_info *spl_image)
 {
 	fixup_memory_node(spl_image);
 }


### PR DESCRIPTION
Port 16ffcff0283d2f10821bad7cbcf89003a86c0063
("spl: split spl_board_fixups to arch/board specific") to sa67.