### PR TITLE
sa67: Fixup DDR size when ECC is enabled

### DIFF
--- a/board/kontron/sa67/sa67.c
+++ b/board/kontron/sa67/sa67.c
@@ -254,6 +254,10 @@ int board_late_init(void)
 #if IS_ENABLED(CONFIG_XPL_BUILD)
 void spl_perform_board_fixups(struct spl_image_info *spl_image)
 {
-	fixup_memory_node(spl_image);
+	if (IS_ENABLED(CONFIG_K3_INLINE_ECC)) {
+		fixup_ddr_driver_for_ecc(spl_image);
+	} else {
+		fixup_memory_node(spl_image);
+	}
 }
 #endif


### PR DESCRIPTION
Port commit bc07851897bd ("board: ti: Pull redundant DDR functions to a common location and Fixup DDR size when ECC is enabled") to sa67.

dram_init() and dram_init_banksize() cannot be removed since they are only implemented in board/ti/common/k3-ddr.c, which we're not including.