### PR TITLE
Revert "sa67: spl: split spl_board_fixups to arch/board specific"

### DIFF
--- a/board/kontron/sa67/sa67.c
+++ b/board/kontron/sa67/sa67.c
@@ -304,7 +304,7 @@ int board_late_init(void)
 }
 
 #if IS_ENABLED(CONFIG_XPL_BUILD)
-void spl_perform_board_fixups(struct spl_image_info *spl_image)
+void spl_perform_fixups(struct spl_image_info *spl_image)
 {
 	if (IS_ENABLED(CONFIG_K3_INLINE_ECC)) {
 		fixup_ddr_driver_for_ecc(spl_image);


### PR DESCRIPTION
Reverts kontron/u-boot-smarc-sam67#2

This breaks the board as the mentioned commit is not part of the v2025.10 release (but probably the next one).